### PR TITLE
Update head.ejs

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -12,7 +12,7 @@
     fb_admins: theme.fb_admins,
     fb_app_id: theme.fb_app_id
   }) %>
-  <link rel="icon" href="favicon.ico">
+  <link rel="icon" href="/favicon.ico">
   <%- partial('google-analytics', { head: true }) %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">


### PR DESCRIPTION
To make favicon available for blog post page. Currently, only top page show favicon