### PR TITLE
fix layout path for config

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -17,14 +17,14 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <%- css('css/style') %>
-  <% if (config.simple_japanese.custom_assets.css) { %>
-    <%- css(config.simple_japanese.custom_assets.css) %>
+  <% if (theme.simple_japanese.custom_assets.css) { %>
+    <%- css(theme.simple_japanese.custom_assets.css) %>
   <% } %>
   <%- partial('gen-structured-data') %>
   <% if (is_post() && config.generator_amp){ %>
     <link rel="amphtml" href="<%= config.url %><%= config.root %><%= page.path.replace(".html", "") %>/amp/index.html">
   <% } %>
-  <% if (config.simple_japanese.custom_assets.js) { %>
-    <%- js(config.simple_japanese.custom_assets.js) %>
+  <% if (theme.simple_japanese.custom_assets.js) { %>
+    <%- js(theme.simple_japanese.custom_assets.js) %>
   <% } %>
 </head>

--- a/layout/_widget/profile.ejs
+++ b/layout/_widget/profile.ejs
@@ -2,12 +2,12 @@
   <div class="widget-title"><%= __('widget.author') %></div>
   <aside class="profile media widget">
     <figure class="profile-avatar media-left">
-      <img src="<%=config.avatar %>" class="avatar" alt="<%=config.author %>">
+      <img src="<%- url_for(theme.avatar) %>" class="avatar" alt="<%=theme.author %>">
     </figure>
     <div class="media-content">
       <p>
         <strong>
-          <span><%=config.author %></span>
+          <span><%=theme.author %></span>
           <span class="icon">
             <a href="<%- url_for(theme.contact.url) %>" target="_blank">
               <i class="fa fa-<%=theme.contact.icon %>"></i>
@@ -15,7 +15,7 @@
           </span>
         </strong>
         <br>
-        <span><%= config.author_title %></span>
+        <span><%= theme.author_title %></span>
       </p>
     </div>
   </aside>


### PR DESCRIPTION
Thanks. I like this theme and I use it.
But... I was troubled with the its initial settings.

The "README" says,
```
## Configuration
following settings are for theme.
 ```
but  some layout files reference not "[HexoDirectory]/theme/simple-japanese/config.yml" but "[hexoDirectory]/config.yml"
So I encounter an error when my first set this theme according to the sample in "README.md".

I wondered if I should fix README file. But I decided to fix layout files because I think it should be placed design settings such as custom_css under the theme directory.